### PR TITLE
Add dragon species with wing hand slots

### DIFF
--- a/Resources/Locale/en-US/species/species.ftl
+++ b/Resources/Locale/en-US/species/species.ftl
@@ -3,6 +3,7 @@
 species-name-human = Human
 species-name-dwarf = Dwarf
 species-name-reptilian = Reptilian
+species-name-dragon = Dragon
 species-name-slime = Slime Person
 species-name-diona = Diona
 species-name-arachnid = Arachnid

--- a/Resources/Locale/ru-RU/species/species.ftl
+++ b/Resources/Locale/ru-RU/species/species.ftl
@@ -3,6 +3,7 @@
 species-name-human = Человек
 species-name-dwarf = Дворф
 species-name-reptilian = Унатх
+species-name-dragon = Дракон
 species-name-slime = Слаймолюд
 species-name-diona = Диона
 species-name-arachnid = Арахнид

--- a/Resources/Prototypes/Body/Parts/dragon.yml
+++ b/Resources/Prototypes/Body/Parts/dragon.yml
@@ -1,0 +1,135 @@
+- type: entity
+  id: PartDragon
+  parent: [BaseItem, BasePart]
+  name: "dragon body part"
+  abstract: true
+  components:
+  - type: Extractable
+    juiceSolution:
+      reagents:
+      - ReagentId: Fat
+        Quantity: 3
+      - ReagentId: Blood
+        Quantity: 10
+
+- type: entity
+  id: TorsoDragon
+  name: "dragon torso"
+  parent: [PartDragon, BaseTorso]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: "torso_m"
+  - type: Extractable
+    juiceSolution:
+      reagents:
+      - ReagentId: Fat
+        Quantity: 10
+      - ReagentId: Blood
+        Quantity: 20
+
+- type: entity
+  id: HeadDragon
+  name: "dragon head"
+  parent: [PartDragon, BaseHead]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: "head_m"
+  - type: Extractable
+    juiceSolution:
+      reagents:
+      - ReagentId: Fat
+        Quantity: 5
+      - ReagentId: Blood
+        Quantity: 10
+
+- type: entity
+  id: LeftArmDragon
+  name: "left dragon arm"
+  parent: [PartDragon, BaseLeftArm]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: "l_arm"
+
+- type: entity
+  id: RightArmDragon
+  name: "right dragon arm"
+  parent: [PartDragon, BaseRightArm]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: "r_arm"
+
+- type: entity
+  id: LeftHandDragon
+  name: "left dragon hand"
+  parent: [PartDragon, BaseLeftHand]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: "l_hand"
+
+- type: entity
+  id: RightHandDragon
+  name: "right dragon hand"
+  parent: [PartDragon, BaseRightHand]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: "r_hand"
+
+- type: entity
+  id: LeftWingDragon
+  name: "left dragon wing"
+  parent: [PartDragon, BaseLeftHand]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: "l_hand"
+
+- type: entity
+  id: RightWingDragon
+  name: "right dragon wing"
+  parent: [PartDragon, BaseRightHand]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: "r_hand"
+
+- type: entity
+  id: LeftLegDragon
+  name: "left dragon leg"
+  parent: [PartDragon, BaseLeftLeg]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: "l_leg"
+
+- type: entity
+  id: RightLegDragon
+  name: "right dragon leg"
+  parent: [PartDragon, BaseRightLeg]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: "r_leg"
+
+- type: entity
+  id: LeftFootDragon
+  name: "left dragon foot"
+  parent: [PartDragon, BaseLeftFoot]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: "l_foot"
+
+- type: entity
+  id: RightFootDragon
+  name: "right dragon foot"
+  parent: [PartDragon, BaseRightFoot]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: "r_foot"

--- a/Resources/Prototypes/Body/Prototypes/dragon.yml
+++ b/Resources/Prototypes/Body/Prototypes/dragon.yml
@@ -1,0 +1,55 @@
+﻿- type: body
+  id: Dragon
+  name: "dragon"
+  root: torso
+  slots:
+    head:
+      part: HeadDragon
+      connections:
+      - torso
+      organs:
+        brain: OrganHumanBrain
+        eyes: OrganHumanEyes
+    torso:
+      part: TorsoDragon
+      connections:
+      - right_arm
+      - left_arm
+      - right_leg
+      - left_leg
+      - right_wing
+      - left_wing
+      organs:
+        heart: OrganHumanHeart
+        lungs: OrganHumanLungs
+        stomach: OrganHumanStomach
+        liver: OrganHumanLiver
+        kidneys: OrganHumanKidneys
+    right_arm:
+      part: RightArmDragon
+      connections:
+      - right_hand
+    left_arm:
+      part: LeftArmDragon
+      connections:
+      - left_hand
+    right_hand:
+      part: RightHandDragon
+    left_hand:
+      part: LeftHandDragon
+    right_wing:
+      part: RightWingDragon
+    left_wing:
+      part: LeftWingDragon
+    right_leg:
+      part: RightLegDragon
+      connections:
+      - right_foot
+    left_leg:
+      part: LeftLegDragon
+      connections:
+      - left_foot
+    right_foot:
+      part: RightFootDragon
+    left_foot:
+      part: LeftFootDragon

--- a/Resources/Prototypes/Entities/Mobs/Species/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dragon.yml
@@ -1,0 +1,189 @@
+- type: entity
+  save: false
+  name: Urisst' Drakon
+  parent: BaseMobSpeciesOrganic
+  id: BaseMobDragon
+  abstract: true
+  components:
+  - type: HumanoidAppearance
+    species: Dragon
+    hideLayersOnEquip:
+    - Snout
+    - HeadTop
+    - HeadSide
+    - Tail
+    undergarmentBottom: UndergarmentBottomBoxersReptilian
+  - type: Hunger
+  - type: Puller
+    needsHands: false
+  - type: Thirst
+  - type: Icon
+    sprite: Mobs/Species/Reptilian/parts.rsi
+    state: full
+  - type: Body
+    prototype: Dragon
+    requiredLegs: 2
+  - type: Butcherable
+    butcheringType: Spike
+    spawned:
+    - id: FoodMeatLizard
+      amount: 5
+  - type: LizardAccent
+  - type: Speech
+    speechSounds: Lizard
+    speechVerb: Reptilian
+    allowedEmotes: ['Thump']
+  - type: TypingIndicator
+    proto: lizard
+  - type: Vocal
+    sounds:
+      Male: MaleReptilian
+      Female: FemaleReptilian
+      Unsexed: MaleReptilian
+  - type: BodyEmotes
+    soundsId: ReptilianBodyEmotes
+  - type: Damageable
+    damageContainer: Biological
+    damageModifierSet: Scale
+  - type: MeleeWeapon
+    soundHit:
+      collection: AlienClaw
+    angle: 30
+    animation: WeaponArcClaw
+    damage:
+      types:
+        Slash: 5
+  - type: Temperature
+    currentTemperature: 310.15
+    specificHeat: 42
+  - type: TemperatureDamage
+    heatDamageThreshold: 400
+    coldDamageThreshold: 285
+    coldDamage:
+      types:
+        Cold : 0.1 #per second, scales with temperature & other constants
+    heatDamage:
+      types:
+        Heat : 1.5 #per second, scales with temperature & other constants
+  - type: TemperatureSpeed
+    thresholds:
+      301: 0.9
+      295: 0.8
+      285: 0.7
+  - type: Wagging
+  - type: Inventory
+    speciesId: dragon
+    femaleDisplacements:
+      jumpsuit:
+        sizeMaps:
+          32:
+            sprite: Corvax/Mobs/Species/displacement.rsi # Corvax-Digitigrade
+            state: jumpsuit-female
+      head:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Reptilian/displacement.rsi
+            state: head
+      mask:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Reptilian/displacement.rsi
+            state: mask
+      # Corvax-Digitigrade-Start
+      shoes:
+        sizeMaps:
+          32:
+            sprite: Corvax/Mobs/Species/displacement.rsi
+            state: shoes
+      # Corvax-Displacements-End
+    displacements:
+      head:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Reptilian/displacement.rsi
+            state: head
+      mask:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Reptilian/displacement.rsi
+            state: mask
+    # Corvax-Digitigrade-Start
+      jumpsuit:
+        sizeMaps:
+          32:
+            sprite: Corvax/Mobs/Species/displacement.rsi
+            state: jumpsuit
+      shoes:
+        sizeMaps:
+          32:
+            sprite: Corvax/Mobs/Species/displacement.rsi
+            state: shoes
+    # Corvax-Digitigrade-End
+
+- type: entity
+  parent: BaseSpeciesDummy
+  id: MobDragonDummy
+  categories: [ HideSpawnMenu ]
+  description: A dummy dragon meant to be used in character setup.
+  components:
+  - type: HumanoidAppearance
+    species: Dragon
+    hideLayersOnEquip:
+    - Snout
+    - HeadTop
+    - HeadSide
+    undergarmentBottom: UndergarmentBottomBoxersReptilian
+  - type: Inventory
+    speciesId: dragon
+    femaleDisplacements:
+      jumpsuit:
+        sizeMaps:
+          32:
+            sprite: Corvax/Mobs/Species/displacement.rsi # Corvax-Digitigrade
+            state: jumpsuit-female
+      head:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Reptilian/displacement.rsi
+            state: head
+      mask:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Reptilian/displacement.rsi
+            state: mask
+      # Corvax-Digitigrade-Start
+      shoes:
+        sizeMaps:
+          32:
+            sprite: Corvax/Mobs/Species/displacement.rsi
+            state: shoes
+      # Corvax-Displacements-End
+    displacements:
+      head:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Reptilian/displacement.rsi
+            state: head
+      mask:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Reptilian/displacement.rsi
+            state: mask
+    # Corvax-Digitigrade-Start
+      jumpsuit:
+        sizeMaps:
+          32:
+            sprite: Corvax/Mobs/Species/displacement.rsi
+            state: jumpsuit
+      shoes:
+        sizeMaps:
+          32:
+            sprite: Corvax/Mobs/Species/displacement.rsi
+            state: shoes
+    # Corvax-Digitigrade-End
+
+- type: entity
+  save: false
+  name: Urisst' Drakon
+  parent: BaseMobDragon
+  id: MobDragon

--- a/Resources/Prototypes/Species/dragon.yml
+++ b/Resources/Prototypes/Species/dragon.yml
@@ -1,0 +1,74 @@
+- type: species
+  id: Dragon
+  name: species-name-dragon
+  roundStart: true
+  prototype: MobDragon
+  sprites: MobDragonSprites
+  defaultSkinTone: "#34a223"
+  markingLimits: MobDragonMarkingLimits
+  dollPrototype: MobDragonDummy
+  skinColoration: Hues
+  maleFirstNames: NamesReptilianMale
+  femaleFirstNames: NamesReptilianFemale
+  naming: FirstDashFirst
+
+- type: speciesBaseSprites
+  id: MobDragonSprites
+  sprites:
+    Head: MobReptilianHead
+    Snout: MobHumanoidAnyMarking
+    UndergarmentTop: MobHumanoidAnyMarking
+    UndergarmentBottom: MobHumanoidAnyMarking
+    Chest: MobReptilianTorso
+    HeadTop: MobHumanoidAnyMarking
+    HeadSide: MobHumanoidAnyMarking
+    Tail: MobHumanoidAnyMarking
+    Eyes: MobHumanoidEyes
+    LArm: MobReptilianLArm
+    RArm: MobReptilianRArm
+    LHand: MobReptilianLHand
+    RHand: MobReptilianRHand
+    LLeg: MobReptilianLLegDigi # Corvax-Digitigrade
+    RLeg: MobReptilianRLegDigi # Corvax-Digitigrade
+    LFoot: MobReptilianLFootDigi # Corvax-Digitigrade
+    RFoot: MobReptilianRFootDigi # Corvax-Digitigrade
+
+- type: markingPoints
+  id: MobDragonMarkingLimits
+  onlyWhitelisted: true
+  points:
+    Hair:
+      points: 0
+      required: false
+    FacialHair:
+      points: 0
+      required: false
+    Tail:
+      points: 1
+      required: true
+      defaultMarkings: [ LizardTailSmooth ]
+    Snout:
+      points: 1
+      required: true
+      defaultMarkings: [ LizardSnoutRound ]
+    HeadTop:
+      points: 2
+      required: false
+    HeadSide:
+      points: 1
+      required: false
+    UndergarmentTop:
+      points: 1
+      required: false
+    UndergarmentBottom:
+      points: 1
+      required: false
+    Chest:
+      points: 3
+      required: false
+    Legs:
+      points: 2
+      required: false
+    Arms:
+      points: 2
+      required: false


### PR DESCRIPTION
### Motivation
- Introduce a new playable species `Dragon` whose anatomy includes wings that can function as extra hand slots so dragons can hold items with their wings.
- Provide species, body and part prototypes plus localization so the species is available in character setup and the game can recognize wing body parts as hand-like slots.

### Description
- Added a species prototype at `Resources/Prototypes/Species/dragon.yml` registering `Dragon` and its base sprites/marking limits.
- Added mob and dummy prototypes at `Resources/Prototypes/Entities/Mobs/Species/dragon.yml` to define a dragon mob (`MobDragon`) and base mob (`BaseMobDragon`).
- Added body part prototypes in `Resources/Prototypes/Body/Parts/dragon.yml`, including `LeftWingDragon` and `RightWingDragon` that inherit from hand part types so wings can hold items.
- Added a body prototype at `Resources/Prototypes/Body/Prototypes/dragon.yml` that defines `left_wing` and `right_wing` slots and wires them into the dragon body structure, and updated localization keys in `Resources/Locale/en-US/species/species.ftl` and `Resources/Locale/ru-RU/species/species.ftl`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b281b349c8326b376f7cf71971649)